### PR TITLE
Allow lib to compile with older C++ versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(MSVC)
+    # Make sure MSVC reports __cplusplus w/ the real value.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+endif()
+
 # External dependencies
 include(${CMAKE_SOURCE_DIR}/cmake/dependency.zlib.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/dependency.jpeg.cmake)

--- a/Source/FreeImage/ConversionYUV.cpp
+++ b/Source/FreeImage/ConversionYUV.cpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include "SimpleTools.h"
 
+#if __cplusplus >= 201703L
+
 
 namespace {
 
@@ -102,3 +104,15 @@ FIBITMAP* ConvertYuvToRgb(FIBITMAP* dib, int64_t standard_version)
 
 	return result.release();
 }
+#else
+FIBITMAP* ConvertRgbToYuv(FIBITMAP* dib, int64_t standard_version)
+{
+	return nullptr;
+}
+
+
+FIBITMAP* ConvertYuvToRgb(FIBITMAP* dib, int64_t standard_version)
+{
+	return nullptr;
+}
+#endif

--- a/Source/FreeImage/ConversionYUV.h
+++ b/Source/FreeImage/ConversionYUV.h
@@ -10,9 +10,12 @@
 #include "FreeImage.h"
 #include <type_traits>
 
+#if __cplusplus >= 201703L
+
 // ----------------------------------------------------------
 //  internal conversions from RGB to YUV
 // ----------------------------------------------------------
+
 
 
 /**
@@ -212,9 +215,10 @@ constexpr FIRGB8 RgbToYuv(const FIRGB8& p) {
 
 
 
+#endif // __cplusplus >= 201703L
+
 FIBITMAP* ConvertRgbToYuv(FIBITMAP* dib, int64_t standard_version);
 
 FIBITMAP* ConvertYuvToRgb(FIBITMAP* dib, int64_t standard_version);
-
 
 #endif //FREEIMAGE_CONVERSION_YUV_H_

--- a/Source/FreeImage/SimpleTools.cpp
+++ b/Source/FreeImage/SimpleTools.cpp
@@ -8,7 +8,7 @@
 #include <cstring>
 #include <algorithm>
 
-
+#if __cplusplus >= 201703L
 FIBOOL FreeImage_FindMinMax(FIBITMAP* dib, double* min_brightness, double* max_brightness, void** min_ptr, void** max_ptr)
 {
 	if (!FreeImage_HasPixels(dib)) {
@@ -261,6 +261,17 @@ FIBOOL FreeImage_FindMinMaxValue(FIBITMAP* dib, void* min_value, void* max_value
 
 	return TRUE;
 }
+#else
+FIBOOL FreeImage_FindMinMax(FIBITMAP* dib, double* min_brightness, double* max_brightness, void** min_ptr, void** max_ptr)
+{
+	return FALSE;
+}
+
+FIBOOL FreeImage_FindMinMaxValue(FIBITMAP* dib, void* min_value, void* max_value)
+{
+	return FALSE;
+}
+#endif
 
 
 FIBOOL FreeImage_Fill(FIBITMAP* dib, const void* value_ptr, size_t value_size)

--- a/Source/FreeImage/SimpleTools.h
+++ b/Source/FreeImage/SimpleTools.h
@@ -53,6 +53,8 @@ void BitmapTransform(FIBITMAP* dst, FIBITMAP* src, UnaryOperation_ unary_op)
 	}
 }
 
+#if __cplusplus >= 201703L
+
 template <typename Ty_>
 using IsIntPixelType = std::integral_constant<bool,
     std::is_same_v<Ty_, FIRGB8> ||
@@ -347,6 +349,7 @@ std::tuple<PixelTy_*, PixelTy_*, double, double> FindMinMax(FIBITMAP* src, Brigh
     return std::make_tuple(minIt, maxIt, minVal, maxVal);
 }
 
+#endif
 
 
 #endif //FREEIMAGE_SIMPLE_TOOLS_H_

--- a/Source/FreeImage/tmoClamp.cpp
+++ b/Source/FreeImage/tmoClamp.cpp
@@ -12,6 +12,7 @@
 
 FIBITMAP* FreeImage_TmoClamp(FIBITMAP* src, double max_value)
 {
+#if __cplusplus >= 201703L
     if (!FreeImage_HasPixels(src)) {
         return nullptr;
     }
@@ -137,4 +138,7 @@ FIBITMAP* FreeImage_TmoClamp(FIBITMAP* src, double max_value)
     }
 
     return dst.release();
+#else
+	return nullptr;
+#endif
 }

--- a/Source/FreeImage/tmoLinear.cpp
+++ b/Source/FreeImage/tmoLinear.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <memory>
 
-
+#if __cplusplus >= 201703L
 template <typename YuvStandard_>
 FIBOOL TmoLinearImpl(FIBITMAP* dst, FIBITMAP* src, double maxValue, double minBrightness, double maxBrightness)
 {
@@ -174,3 +174,9 @@ FIBITMAP* FreeImage_TmoLinear(FIBITMAP* src, double max_value, FREE_IMAGE_CVT_CO
     return dst.release();
 
 }
+#else
+FIBITMAP* FreeImage_TmoLinear(FIBITMAP* src, double max_value, FREE_IMAGE_CVT_COLOR_PARAM yuv_standard)
+{
+	return nullptr;
+}
+#endif

--- a/Source/FreeImageToolkit/Colors.cpp
+++ b/Source/FreeImageToolkit/Colors.cpp
@@ -445,7 +445,7 @@ FreeImage_GetHistogram(FIBITMAP *src, uint32_t *histo, FREE_IMAGE_COLOR_CHANNEL 
 	return FALSE;
 }
 
-
+#if __cplusplus >= 201703L
 namespace
 {
 
@@ -934,6 +934,12 @@ FIBOOL FreeImage_MakeHistogram(FIBITMAP* dib, uint32_t binsNumber, void* outMinV
 
 	return success ? TRUE : FALSE;
 }
+#else
+FIBOOL FreeImage_MakeHistogram(FIBITMAP* dib, uint32_t binsNumber, void* outMinVal, void* outMaxVal, uint32_t* histR, uint32_t strideR, uint32_t* histG, uint32_t strideG, uint32_t* histB, uint32_t strideB, uint32_t* histL, uint32_t strideL)
+{
+	return FALSE;
+}
+#endif
 
 
 // ----------------------------------------------------------


### PR DESCRIPTION
The new functionality that requires newer C++ versions has been disabled.
Fortunately the API already supports returning error when the operation failed or was unsupported.

This is a DRAFT because I'm testing this functionality yet to make sure there are no surprises but it appears to be working.