### PR TITLE
Add #define FREEIMAGE_RESURRECTED 1 to give users the ability to distinguish FreeImageRe and FreeImage on source level

### DIFF
--- a/Source/FreeImage.h
+++ b/Source/FreeImage.h
@@ -41,6 +41,8 @@
 #define FREEIMAGE_MINOR_VERSION   18
 #define FREEIMAGE_RELEASE_SERIAL  0
 
+#define FREEIMAGE_RESURRECTED     1
+
 // Compiler options ---------------------------------------------------------
 
 #include <inttypes.h>


### PR DESCRIPTION
On Windows both DWORD (unsigned long) and uint32_t are separate 32bit types, so pointers to them can not be mixed, even if ABI is the same, so third party libraries that want to be compatible with both FreeImageRe and FreeImage and defer choice to the final application - need a way to distinguish FreeImageRe and FreeImage

Example:
```
#ifdef FREEIMAGE_RESURRECTED
        uint32_t size;
#else
        DWORD size;
#endif
        FreeImage_AcquireMemory( mem, &data, &size );
```

Note: Applications that wants to be also compatible with the existing FreeImageRe that has no #define FREEIMAGE_RESURRECTED too - can do something like this:

        #define FISIZE decltype(FIICCPROFILE::size) -or- typedef decltype(FIICCPROFILE::size) FISIZE
                
        FISIZE size;
        FreeImage_AcquireMemory( mem, &data, &size );
        

But that trick should be used for both FreeImageRe and FreeImage, so such FISIZE definition could not be placed into FreeImageRe sources, it should be done in app headers. First approach is also much more intuitive and discoverable.