### PR TITLE
CI: GNU/Linux GCC

### DIFF
--- a/.github/workflows/build_gnulinux.yml
+++ b/.github/workflows/build_gnulinux.yml
@@ -1,0 +1,37 @@
+name: Build GNU/Linux
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            packages: 'gcc-10 g++-10'
+            env_cc: gcc-10
+            env_cxx: g++-10
+          - os: ubuntu-latest
+            packages: 'gcc-14 g++-14'
+            env_cc: gcc-14
+            env_cxx: g++-14
+
+    env:
+      CC: ${{ matrix.env_cc }}
+      CXX: ${{ matrix.env_cxx }}
+
+    name: ${{ matrix.os }} - ${{ matrix.packages }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: install build dependencies
+        run: sudo apt install -y meson nasm ${{ matrix.packages }}
+      - name: cmake
+        run: mkdir build && cd build && cmake ..
+      - name: make
+        run: cd build && make


### PR DESCRIPTION
This adds a compile GitHub Action on GNU/Linux with the GCC toolchain.
This PR is part of addressing #29.

This PR is kept minimal, to be extended further with future PRs to address other toolchains, architectures, make targets, and compile flags.

The selection of GCC 10 & 14 is arbitrary, and can of course be extended with more versions.
I've selected those as they are in Debian 12 Bookworm (oldstable) and Debian 13 Trixie (stable).