### PR TITLE
CI: GNU/Linux LLVM

### DIFF
--- a/.github/workflows/build_gnulinux.yml
+++ b/.github/workflows/build_gnulinux.yml
@@ -20,6 +20,14 @@ jobs:
             packages: 'gcc-14 g++-14'
             env_cc: gcc-14
             env_cxx: g++-14
+          - os: ubuntu-latest
+            packages: 'clang-14'
+            env_cc: clang-14
+            env_cxx: clang++-14
+          - os: ubuntu-latest
+            packages: 'clang-19'
+            env_cc: clang-19
+            env_cxx: clang++-19
 
     env:
       CC: ${{ matrix.env_cc }}


### PR DESCRIPTION
This adds the LLVM toolchain on GNU/Linux for #29 and is based on #42.

The selection of LLVM 14 & 19 is arbitrary, and can of course be extended with more versions.
I've selected those as they are in Debian 12 Bookworm (oldstable) and Debian 13 Trixie (stable).

Marked as draft, as this is currently failing with a type warning and linker error:

```
/home/runner/work/FreeImageRe/FreeImageRe/dependencies/heif/source/libheif/plugins/encoder_svt.cc:866:23: warning: implicit conversion loses integer precision: 'int' to 'uint8_t' (aka 'unsigned char') [-Wimplicit-int-conversion]
      uint8_t val = 1 << (bitdepth_y - 1);
              ~~~   ~~^~~~~~~~~~~~~~~~~~~
/home/runner/work/FreeImageRe/FreeImageRe/dependencies/heif/source/libheif/plugins/encoder_svt.cc:871:24: warning: implicit conversion loses integer precision: 'int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
      uint16_t val = 1 << (bitdepth_y - 1);
               ~~~   ~~^~~~~~~~~~~~~~~~~~~
2 warnings generated.
[...]
/usr/bin/ld: /home/runner/work/FreeImageRe/FreeImageRe/build/svtav1/install/lib/libSvtAv1Enc.a: error adding symbols: file format not recognized
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```