### PR TITLE
CI: GNU/Linux mingw-w64

### DIFF
--- a/.github/workflows/build_gnulinux.yml
+++ b/.github/workflows/build_gnulinux.yml
@@ -20,6 +20,14 @@ jobs:
             packages: 'gcc-14 g++-14'
             env_cc: gcc-14
             env_cxx: g++-14
+          - os: ubuntu-latest
+            packages: 'mingw-w64'
+            env_cc: x86_64-w64-mingw32-gcc-posix
+            env_cxx: x86_64-w64-mingw32-g++-posix
+          - os: ubuntu-latest
+            packages: 'mingw-w64'
+            env_cc: x86_64-w64-mingw32-gcc-win32
+            env_cxx: x86_64-w64-mingw32-g++-win32
 
     env:
       CC: ${{ matrix.env_cc }}


### PR DESCRIPTION
This is a rough/potential start for #29 with the mingw-w64 toolchain on GNU/Linux and based on #42.
I'm lacking experience with MinGW to work on this and don't even know if this is the right approach.
But I think this could be a good starting point for someone who does and take this over.

Marked as draft, as this is currently failing with the following error:

```
CMake Error at /usr/local/share/cmake-3.31/Modules/CheckTypeSize.cmake:156 (try_compile):
  Cannot copy output executable

    ''

  to destination specified by COPY_FILE:

    '/home/runner/work/FreeImageRe/FreeImageRe/build/zlib/build/CMakeFiles/CheckTypeSize/OFF64_T.bin'

  because:

    No such file or directory (input)

  Recorded try_compile output location doesn't exist:

    /home/runner/work/FreeImageRe/FreeImageRe/build/zlib/build/CMakeFiles/CMakeScratch/TryCompile-dBgh6T/cmTC_306a0

Call Stack (most recent call first):
  /usr/local/share/cmake-3.31/Modules/CheckTypeSize.cmake:283 (__check_type_size_impl)
  CMakeLists.txt:42 (check_type_size)
```