### PR TITLE
CI: Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds Dependabot, monitoring our dependencies that the GitHub Actions (which are in in `.github/workflows`) are using.
As GitHub Actions typically use semver and are specified with only the major version, updates should be rare and not security-critical.