### PR TITLE
Update to libpng 1.6.55

### DIFF
--- a/cmake/dependency.png.cmake
+++ b/cmake/dependency.png.cmake
@@ -12,9 +12,8 @@ unset(INSTALL_DIR)
 
 ExternalProject_Add(PNG
     PREFIX ${EXTERNALPROJECT_BINARY_ROOT}/png
-    GIT_REPOSITORY "https://github.com/pnggroup/libpng.git"
-    GIT_TAG "v1.6.55"
-    GIT_SHALLOW ON
+    URL "https://github.com/pnggroup/libpng/archive/refs/tags/v1.6.55.zip"
+    URL_MD5 "f64ff4e41a5bbbea9e1432b3b13947f1"
     DOWNLOAD_DIR "${EXTERNALPROJECT_SOURCE_ROOT}/png"
     SOURCE_DIR "${EXTERNALPROJECT_SOURCE_PREFIX}/png/source"
     BINARY_DIR "${EXTERNALPROJECT_BINARY_ROOT}/png/build"


### PR DESCRIPTION
Uses git instead of computing checksum of zip file.