### PR TITLE
Fixed compilation under Win32 with Clang

### DIFF
--- a/3rdParty/LibJXR/image/decode/segdec.c
+++ b/3rdParty/LibJXR/image/decode/segdec.c
@@ -52,7 +52,9 @@ static Int DecodeSignificantAbsLevel (struct CAdaptiveHuffman *pAHexpt, BitIOInf
 //================================================================
 // Memory access functions
 //================================================================
+#if !((defined(WIN32) && !defined(UNDER_CE) && (!defined(__MINGW32__) || defined(__MINGW64_TOOLCHAIN__))) || (defined(UNDER_CE) && defined(_ARM_)))
 U32 _byteswap_ulong(U32);
+#endif
 
 static U32 _FORCEINLINE _load4(void* pv)
 {


### PR DESCRIPTION
## Summary

  Fix FreeImage/LibJXR build failure with clang-cl caused by a conflicting `_byteswap_ulong` declaration in LibJXR.

  ## Problem

  LibJXR already guarded its `_byteswap_ulong` **implementation** in `strcodec.c`:

  ```c
  #if (defined(WIN32) && !defined(UNDER_CE) && (!defined(__MINGW32__) || defined(__MINGW64_TOOLCHAIN__))) || ...
  // use platform-provided _byteswap_ulong
  #else
  U32 _byteswap_ulong(U32 bits)
  {
      ...
  }
  #endif
```
  However, segdec.c still had an unconditional forward declaration:

  U32 _byteswap_ulong(U32);

  On Windows with UCRT, _byteswap_ulong is already declared by the CRT as taking/returning unsigned long. LibJXR’s U32 is unsigned int, so clang-cl reports a conflicting declaration even though both types are
  32-bit on Windows.

  ## Fix

  Guard the segdec.c declaration with the same platform condition used by the implementation path.

  This keeps desktop Windows builds using the CRT-provided _byteswap_ulong, while preserving the LibJXR fallback declaration for platforms that need LibJXR’s own implementation.